### PR TITLE
aoe-mkdevs.sh: Man page typo.

### DIFF
--- a/aoe-mkdevs.8
+++ b/aoe-mkdevs.8
@@ -10,7 +10,7 @@ aoe-mkdevs \- create special device files for aoe driver
 The
 .I aoe-mkdevs
 command is deprecated in favor of udev.  Systems with udev do not need
-to use the \fIaoe-mkdevs\fP or \fIaoe-mkself\fP commands, because udev
+to use the \fIaoe-mkdevs\fP or \fIaoe-mkshelf\fP commands, because udev
 will create device nodes as needed.
 .PP
 Systems without udev use \fIaoe-mkdevs\fP to create the character


### PR DESCRIPTION
Minor typo in aoe-mkdevs man page.