### PR TITLE
Change shell script interpreter from /bin/bash to /bin/sh

### DIFF
--- a/aoe-stat.in
+++ b/aoe-stat.in
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 # aoe-stat - collate and present information about AoE storage
 # Copyright 2012, CORAID, Inc., and licensed under GPL v.2.
 


### PR DESCRIPTION
This will make the script more portable, making it possible to run on
systems that do not have bash.

Signed-off-by: Sergio Prado <sergio.prado@e-labworks.com>