### PR TITLE
fix typos

### DIFF
--- a/aoecfg.8
+++ b/aoecfg.8
@@ -7,7 +7,7 @@ aoecfg \- manipulate AoE configuration strings
 .fi
 .SH DESCRIPTION
 .IR Aoecfg (8)
-sends AoE configuration commands that control the retrivial, conditional
+sends AoE configuration commands that control the retrieval, conditional
 or unconditional setting of AoE configuration strings.  Since configuration
 happens before the MAC address of the target is known, the packet is
 broadcast.  AoE targets with a matching shelf and slot respond.  Since

--- a/devnodes.txt
+++ b/devnodes.txt
@@ -17,7 +17,7 @@ of the device nodes.)
 
 If you use an aoe driver from the CORAID website
 (http://support.coraid.com/support/linux/) then just use the aoetools that
-come bundled with that deiver.  If you don't have udev, make sure you
+come bundled with that driver.  If you don't have udev, make sure you
 always load the aoe module with the aoe_dyndevs=0 option for any
 driver version above 49.
 


### PR DESCRIPTION
Closes https://github.com/OpenAoE/aoetools/issues/8

@ecashin 

Some typos were already fixed here but remain present in the sibling aoe repository.

`https://github.com/OpenAoE/aoe/pull/15`