### PR TITLE
Remove the OpenAOE website reference, as it no longer exists

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+2026-02-02 Yacine Kheddache <yacine@kheddache.me>
+	remove the OpenAOE website reference, as it no longer exists
+
 2021-05-21 Christoph Biedl <debian.axhn@manchmal.in-ulm.de>
 	document and raise the maximum number of aoe-sancheck interfaces
 

--- a/README
+++ b/README
@@ -53,6 +53,3 @@ The aoetools on github
 
 The aoetools homepage
   http://aoetools.sourceforge.net/
-
-OpenAoE
-  http://www.openaoe.org/


### PR DESCRIPTION
Remove the OpenAOE website from the README file, as it no longer exists fix #4 